### PR TITLE
feat(browser): lightpanda + unified engines

### DIFF
--- a/.github/workflows/manual-smoke-test.yml
+++ b/.github/workflows/manual-smoke-test.yml
@@ -1,0 +1,56 @@
+name: Manual SPA smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-url:
+        description: "URL to smoke-test"
+        required: true
+        type: string
+      target-selector:
+        description: "Selector to query"
+        required: true
+        type: string
+      request-url:
+        description: "Request to spy (optional)"
+        required: false
+        type: string
+      http-auth-username:
+        description: "Username for HTTP Basic Auth (optional)"
+        required: false
+        type: string
+      http-auth-password:
+        description: "Password for HTTP Basic Auth (optional)"
+        required: false
+        type: string
+      wait-on-start:
+        description: "Waiting duration before asserting (ms, optional)"
+        required: false
+        default: "0"
+        type: string
+      engine:
+        description: "Browser engine to use (lightpanda, playwright, puppeteer)"
+        required: false
+        default: "lightpanda"
+        type: string
+      browser:
+        description: "Browser name for Playwright engine (chromium, firefox, webkit)"
+        required: false
+        default: "chromium"
+        type: string
+
+jobs:
+  run-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run SPA smoke test
+        uses: GabrielCousin/spa-smoke-test-action@v0.3.0
+        with:
+          target-url: ${{ github.event.inputs["target-url"] }}
+          target-selector: ${{ github.event.inputs["target-selector"] }}
+          request-url: ${{ github.event.inputs["request-url"] }}
+          http-auth-username: ${{ github.event.inputs["http-auth-username"] }}
+          http-auth-password: ${{ github.event.inputs["http-auth-password"] }}
+          wait-on-start: ${{ github.event.inputs["wait-on-start"] }}
+          engine: ${{ github.event.inputs["engine"] }}
+          browser: ${{ github.event.inputs["browser"] }}

--- a/.github/workflows/manual-smoke-test.yml
+++ b/.github/workflows/manual-smoke-test.yml
@@ -21,14 +21,9 @@ on:
         default: "0"
         type: string
       engine:
-        description: "Browser engine to use (lightpanda, playwright, puppeteer)"
+        description: "Browser engine to use (lightpanda, puppeteer, playwright-chrome, playwright-firefox)"
         required: false
         default: "lightpanda"
-        type: string
-      browser:
-        description: "Browser name for Playwright engine (chromium, firefox, webkit)"
-        required: false
-        default: "chromium"
         type: string
 
 jobs:
@@ -43,4 +38,3 @@ jobs:
           request-url: ${{ github.event.inputs["request-url"] }}
           wait-on-start: ${{ github.event.inputs["wait-on-start"] }}
           engine: ${{ github.event.inputs["engine"] }}
-          browser: ${{ github.event.inputs["browser"] }}

--- a/.github/workflows/manual-smoke-test.yml
+++ b/.github/workflows/manual-smoke-test.yml
@@ -26,6 +26,9 @@ on:
         default: "lightpanda"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run-smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-smoke-test.yml
+++ b/.github/workflows/manual-smoke-test.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SPA smoke test
-        uses: GabrielCousin/spa-smoke-test-action@v0.3.0
+        uses: GabrielCousin/spa-smoke-test-action@latest
         with:
-          target-url: ${{ github.event.inputs["target-url"] }}
-          target-selector: ${{ github.event.inputs["target-selector"] }}
-          request-url: ${{ github.event.inputs["request-url"] }}
-          wait-on-start: ${{ github.event.inputs["wait-on-start"] }}
-          engine: ${{ github.event.inputs["engine"] }}
+          target-url: ${{ inputs.target-url }}
+          target-selector: ${{ inputs.target-selector }}
+          request-url: ${{ inputs.request-url }}
+          wait-on-start: ${{ inputs.wait-on-start }}
+          engine: ${{ inputs.engine }}

--- a/.github/workflows/manual-smoke-test.yml
+++ b/.github/workflows/manual-smoke-test.yml
@@ -15,14 +15,6 @@ on:
         description: "Request to spy (optional)"
         required: false
         type: string
-      http-auth-username:
-        description: "Username for HTTP Basic Auth (optional)"
-        required: false
-        type: string
-      http-auth-password:
-        description: "Password for HTTP Basic Auth (optional)"
-        required: false
-        type: string
       wait-on-start:
         description: "Waiting duration before asserting (ms, optional)"
         required: false
@@ -49,8 +41,6 @@ jobs:
           target-url: ${{ github.event.inputs["target-url"] }}
           target-selector: ${{ github.event.inputs["target-selector"] }}
           request-url: ${{ github.event.inputs["request-url"] }}
-          http-auth-username: ${{ github.event.inputs["http-auth-username"] }}
-          http-auth-password: ${{ github.event.inputs["http-auth-password"] }}
           wait-on-start: ${{ github.event.inputs["wait-on-start"] }}
           engine: ${{ github.event.inputs["engine"] }}
           browser: ${{ github.event.inputs["browser"] }}

--- a/.swcrc
+++ b/.swcrc
@@ -1,6 +1,6 @@
 {
   "jsc": {
-    "target": "es2022",
+    "target": "es2024",
     "parser": {
       "syntax": "typescript",
       "tsx": false,

--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,18 @@
+{
+  "jsc": {
+    "target": "es2022",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": false,
+      "decorators": false,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": false
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  },
+  "sourceMaps": "inline"
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SPA smoke-test 🚭 action
 
-GitHub action that runs very basic smoke tests for your single-page apps with Puppeteer.
+GitHub action that runs very basic smoke tests for your single-page apps using the Lightpanda headless browser by default (with a Puppeteer-compatible API).
 
 ## Usage
 
-```
+````
 on:
   deployment_status:
 
@@ -32,4 +32,34 @@ jobs:
 
         # Optional wait period before starting the test
         wait-on-start: 1000
+
+        # Optional engine selection (lightpanda, puppeteer, playwright)
+        engine: "lightpanda"
+
+        # Optional browser selection for Playwright engine (chromium, firefox, webkit)
+        browser: "chromium"
+
+## Manual testing via workflow dispatch
+
+You can also trigger the smoke test manually from the GitHub UI using the included `Manual SPA smoke test` workflow:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      target-url:
+        description: "URL to smoke-test"
+        required: true
+        type: string
+      target-selector:
+        description: "Selector to query"
+        required: true
+        type: string
+      # ...other optional inputs...
+````
+
+This workflow forwards the provided inputs to `GabrielCousin/spa-smoke-test-action@v0.3.0`, allowing you to choose the `engine` (`lightpanda`, `playwright`, or `puppeteer`) and, when using Playwright, the `browser` (`chromium`, `firefox`, or `webkit`).
+
+```
+
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub action that runs very basic smoke tests for your single-page apps using t
 
 ## Usage
 
-```yaml
+````yaml
 on:
   deployment_status:
 
@@ -29,11 +29,8 @@ jobs:
         # Optional wait period before starting the test
         wait-on-start: 1000
 
-        # Optional engine selection (lightpanda, puppeteer, playwright)
+        # Optional engine selection (lightpanda, puppeteer, playwright-chrome, playwright-firefox)
         engine: "lightpanda"
-
-        # Optional browser selection for Playwright engine (chromium, firefox, webkit)
-        browser: "chromium"
 
 ## Manual testing via workflow dispatch
 
@@ -52,6 +49,6 @@ on:
         required: true
         type: string
       # ...other optional inputs...
-```
+````
 
-This workflow forwards the provided inputs to `GabrielCousin/spa-smoke-test-action@v0.3.0`, allowing you to choose the `engine` (`lightpanda`, `playwright`, or `puppeteer`) and, when using Playwright, the `browser` (`chromium`, `firefox`, or `webkit`).
+This workflow forwards the provided inputs to `GabrielCousin/spa-smoke-test-action@v0.3.0`, allowing you to choose the `engine` (`lightpanda`, `puppeteer`, `playwright-chrome`, or `playwright-firefox`).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub action that runs very basic smoke tests for your single-page apps using t
 
 ## Usage
 
-````
+```yaml
 on:
   deployment_status:
 
@@ -25,10 +25,6 @@ jobs:
 
         # Some request URL to spy - will not check against any response
         request-url: "https://your-endpoint.tld"
-
-        # Enable HTTP Basic Authentication
-        http-auth-username: "USERNAME"
-        http-auth-password: "PASSWORD"
 
         # Optional wait period before starting the test
         wait-on-start: 1000
@@ -56,10 +52,6 @@ on:
         required: true
         type: string
       # ...other optional inputs...
-````
+```
 
 This workflow forwards the provided inputs to `GabrielCousin/spa-smoke-test-action@v0.3.0`, allowing you to choose the `engine` (`lightpanda`, `playwright`, or `puppeteer`) and, when using Playwright, the `browser` (`chromium`, `firefox`, or `webkit`).
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPA smoke-test 🚭 action
 
-GitHub action that runs very basic smoke tests for your single-page apps using the Lightpanda headless browser by default (with a Puppeteer-compatible API).
+GitHub action that runs very basic smoke tests for your single-page apps using the [Lightpanda headless browser](https://github.com/lightpanda-io/browser) by default (with a [Puppeteer](https://pptr.dev/)–compatible API and optional [Playwright](https://playwright.dev/) support).
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,9 @@ inputs:
   wait-on-start:
     description: "Waiting duration before asserting"
   engine:
-    description: "Browser engine to use (lightpanda, playwright, puppeteer)"
+    description: "Browser engine to use (lightpanda, puppeteer, playwright-chrome, playwright-firefox)"
     required: false
     default: "lightpanda"
-  browser:
-    description: "Browser name for Playwright engine (chromium, firefox, webkit)"
-    required: false
-    default: "chromium"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: false
     default: "chromium"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,6 @@ inputs:
     required: true
   request-url:
     description: "Request to spy"
-  http-auth-username:
-    description: "Username for HTTP Basic Auth"
-  http-auth-password:
-    description: "Password for HTTP Basic Auth"
   wait-on-start:
     description: "Waiting duration before asserting"
   engine:

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: "Password for HTTP Basic Auth"
   wait-on-start:
     description: "Waiting duration before asserting"
+  engine:
+    description: "Browser engine to use (lightpanda, playwright, puppeteer)"
+    required: false
+    default: "lightpanda"
+  browser:
+    description: "Browser name for Playwright engine (chromium, firefox, webkit)"
+    required: false
+    default: "chromium"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -7,13 +7,15 @@ const jestPlugin = require("eslint-plugin-jest");
 const jestRecommendedConfig = jestPlugin.configs["flat/recommended"];
 
 /**
- * @type {import('eslint').ESLint.Plugin}
+ * @type {import('eslint').Linter.FlatConfig[]}
  */
 module.exports = [
+  {
+    ignores: ["dist/**"],
+  },
   eslint.configs.recommended,
   ...tsEslint.configs.strict,
   eslintPluginPrettierRecommended,
-
   {
     ...jestRecommendedConfig,
     languageOptions: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   clearMocks: true,
   collectCoverage: true,
   collectCoverageFrom: ["src/**/*.ts", "!**/node_modules/**", "!src/index.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest"],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,13 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^2.0.0",
-        "puppeteer": "^24.37.5"
+        "puppeteer": "^24.37.5",
+        "puppeteer-core": "^24.3.0"
       },
       "devDependencies": {
         "@jest/globals": "^30.2.0",
+        "@swc/core": "^1.15.18",
+        "@swc/jest": "^0.2.39",
         "@tsconfig/node20": "^20.1.9",
         "@types/jest": "^30.0.0",
         "@vercel/ncc": "^0.38.4",
@@ -24,8 +27,8 @@
         "eslint-plugin-prettier": "^5.5.5",
         "globals": "^17.3.0",
         "jest": "^30.2.0",
+        "playwright": "^1.58.2",
         "prettier": "^3.6.2",
-        "ts-jest": "^29.4.6",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.56.1"
       },
@@ -133,6 +136,7 @@
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1142,6 +1146,38 @@
         }
       }
     },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.3.0.tgz",
+      "integrity": "sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/diff-sequences": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
@@ -1541,6 +1577,251 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
+      "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.18",
+        "@swc/core-darwin-x64": "1.15.18",
+        "@swc/core-linux-arm-gnueabihf": "1.15.18",
+        "@swc/core-linux-arm64-gnu": "1.15.18",
+        "@swc/core-linux-arm64-musl": "1.15.18",
+        "@swc/core-linux-x64-gnu": "1.15.18",
+        "@swc/core-linux-x64-musl": "1.15.18",
+        "@swc/core-win32-arm64-msvc": "1.15.18",
+        "@swc/core-win32-ia32-msvc": "1.15.18",
+        "@swc/core-win32-x64-msvc": "1.15.18"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.18.tgz",
+      "integrity": "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.18.tgz",
+      "integrity": "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.18.tgz",
+      "integrity": "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.18.tgz",
+      "integrity": "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.18.tgz",
+      "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
+      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.18.tgz",
+      "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.18.tgz",
+      "integrity": "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.18.tgz",
+      "integrity": "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.18.tgz",
+      "integrity": "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/jest": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^30.0.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -1706,6 +1987,7 @@
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -1745,6 +2027,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2274,6 +2557,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2656,6 +2940,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2667,18 +2952,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -2990,7 +3263,8 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3097,6 +3371,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3157,6 +3432,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3754,28 +4030,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4073,6 +4327,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -4728,6 +4983,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4781,12 +5043,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4817,12 +5073,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4875,16 +5125,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4927,13 +5167,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -5282,6 +5515,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5297,6 +5577,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5899,6 +6180,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5937,59 +6219,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.7.3",
-        "type-fest": "^4.41.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0 || ^30.0.0",
-        "@jest/types": "^29.0.0 || ^30.0.0",
-        "babel-jest": "^29.0.0 || ^30.0.0",
-        "jest": "^29.0.0 || ^30.0.0",
-        "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/transform": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jest-util": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6026,19 +6255,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typed-query-selector": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
@@ -6051,6 +6267,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6081,20 +6298,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/unrs-resolver": {
@@ -6217,13 +6420,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -6468,6 +6664,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -7159,6 +7356,32 @@
         "slash": "^3.0.0"
       }
     },
+    "@jest/create-cache-key-function": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.3.0.tgz",
+      "integrity": "sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.3.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "30.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+          "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+          "dev": true,
+          "requires": {
+            "@jest/pattern": "30.0.1",
+            "@jest/schemas": "30.0.5",
+            "@types/istanbul-lib-coverage": "^2.0.6",
+            "@types/istanbul-reports": "^3.0.4",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.33",
+            "chalk": "^4.1.2"
+          }
+        }
+      }
+    },
     "@jest/diff-sequences": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
@@ -7458,6 +7681,123 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "@swc/core": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
+      "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@swc/core-darwin-arm64": "1.15.18",
+        "@swc/core-darwin-x64": "1.15.18",
+        "@swc/core-linux-arm-gnueabihf": "1.15.18",
+        "@swc/core-linux-arm64-gnu": "1.15.18",
+        "@swc/core-linux-arm64-musl": "1.15.18",
+        "@swc/core-linux-x64-gnu": "1.15.18",
+        "@swc/core-linux-x64-musl": "1.15.18",
+        "@swc/core-win32-arm64-msvc": "1.15.18",
+        "@swc/core-win32-ia32-msvc": "1.15.18",
+        "@swc/core-win32-x64-msvc": "1.15.18",
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.18.tgz",
+      "integrity": "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.18.tgz",
+      "integrity": "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.18.tgz",
+      "integrity": "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.18.tgz",
+      "integrity": "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.18.tgz",
+      "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
+      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.18.tgz",
+      "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.18.tgz",
+      "integrity": "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.18.tgz",
+      "integrity": "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.18.tgz",
+      "integrity": "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
+    },
+    "@swc/jest": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+      "dev": true,
+      "requires": {
+        "@jest/create-cache-key-function": "^30.0.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      }
+    },
+    "@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "dev": true,
+      "requires": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -7607,6 +7947,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -7631,6 +7972,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -7911,7 +8253,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -8149,20 +8492,12 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
       "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
-      }
-    },
-    "bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "requires": {
-        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -8359,7 +8694,8 @@
     "devtools-protocol": {
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
-      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ=="
+      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "peer": true
     },
     "eastasianwidth": {
       "version": "0.2.0",
@@ -8432,6 +8768,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8482,6 +8819,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-plugin-jest": {
@@ -8852,19 +9190,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9068,6 +9393,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9542,6 +9868,12 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9581,12 +9913,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9606,12 +9932,6 @@
       "requires": {
         "semver": "^7.5.3"
       }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -9653,12 +9973,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
-    },
     "minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -9685,12 +9999,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "netmask": {
@@ -9935,6 +10243,31 @@
         }
       }
     },
+    "playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.58.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9945,7 +10278,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.1",
@@ -10356,7 +10690,8 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -10381,23 +10716,6 @@
       "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "requires": {}
-    },
-    "ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
-      "dev": true,
-      "requires": {
-        "bs-logger": "^0.2.6",
-        "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.7.3",
-        "type-fest": "^4.41.0",
-        "yargs-parser": "^21.1.1"
-      }
     },
     "tslib": {
       "version": "2.8.1",
@@ -10424,12 +10742,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
-    "type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true
-    },
     "typed-query-selector": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
@@ -10439,7 +10751,8 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "typescript-eslint": {
       "version": "8.56.1",
@@ -10452,13 +10765,6 @@
         "@typescript-eslint/typescript-estree": "8.56.1",
         "@typescript-eslint/utils": "8.56.1"
       }
-    },
-    "uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "optional": true
     },
     "unrs-resolver": {
       "version": "1.11.1",
@@ -10540,12 +10846,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
-        "@actions/exec": "^2.0.0",
-        "puppeteer": "^24.37.5",
-        "puppeteer-core": "^24.3.0"
+        "@actions/exec": "^2.0.0"
       },
       "devDependencies": {
         "@jest/globals": "^30.2.0",
         "@swc/core": "^1.15.18",
         "@swc/jest": "^0.2.39",
-        "@tsconfig/node20": "^20.1.9",
+        "@tsconfig/node24": "^24.0.4",
         "@types/jest": "^30.0.0",
         "@vercel/ncc": "^0.38.4",
         "eslint": "^9.39.2",
@@ -29,11 +27,13 @@
         "jest": "^30.2.0",
         "playwright": "^1.58.2",
         "prettier": "^3.6.2",
-        "typescript": "^5.8.3",
+        "puppeteer": "^24.37.5",
+        "puppeteer-core": "^24.3.0",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1"
       },
       "engines": {
-        "node": ">=20.0.0",
+        "node": ">=24.0.0",
         "npm": ">=8.11.0"
       }
     },
@@ -110,6 +110,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -281,6 +282,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1533,6 +1535,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
       "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1826,12 +1829,13 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1946,7 +1950,7 @@
       "version": "20.4.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.7.tgz",
       "integrity": "sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1975,6 +1979,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2579,6 +2584,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2634,6 +2640,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2642,6 +2649,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2668,12 +2676,14 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -2686,6 +2696,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -2805,6 +2816,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -2819,6 +2831,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
       "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2843,6 +2856,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
       "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -2852,6 +2866,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -2861,6 +2876,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
       "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.21.0",
@@ -2883,6 +2899,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -2892,6 +2909,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
       "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2967,6 +2985,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2983,6 +3002,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3048,6 +3068,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
       "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -3084,6 +3105,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3115,6 +3137,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3125,7 +3148,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3143,6 +3167,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3182,6 +3207,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3191,6 +3217,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3239,6 +3266,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
@@ -3263,6 +3291,7 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -3296,12 +3325,14 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3311,6 +3342,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3319,6 +3351,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3327,6 +3360,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3348,6 +3382,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
@@ -3577,6 +3612,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3614,6 +3650,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3622,6 +3659,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3630,6 +3668,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -3704,6 +3743,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -3738,6 +3778,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3765,6 +3806,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -3896,6 +3938,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3914,6 +3957,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -3929,6 +3973,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -4050,6 +4095,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -4063,6 +4109,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -4095,6 +4142,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4158,6 +4206,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4166,7 +4215,8 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4181,6 +4231,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4919,12 +4970,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4956,7 +5009,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5026,7 +5080,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5053,6 +5108,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -5139,12 +5195,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -5172,6 +5230,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -5216,6 +5275,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5297,6 +5357,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -5316,6 +5377,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
@@ -5336,6 +5398,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -5347,6 +5410,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -5416,12 +5480,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5633,6 +5699,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5642,6 +5709,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5661,12 +5729,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -5687,6 +5757,7 @@
       "version": "24.37.5",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.5.tgz",
       "integrity": "sha512-3PAOIQLceyEmn1Fi76GkGO2EVxztv5OtdlB1m8hMUZL3f8KDHnlvXbvCXv+Ls7KzF1R0KdKBqLuT/Hhrok12hQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5708,6 +5779,7 @@
       "version": "24.37.5",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
       "integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
@@ -5750,6 +5822,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5781,6 +5854,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5789,6 +5863,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5837,6 +5912,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -5847,6 +5923,7 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.0.1",
@@ -5861,6 +5938,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5875,7 +5953,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5923,6 +6001,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
       "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -5948,6 +6027,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5977,6 +6057,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6062,6 +6143,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -6076,6 +6158,7 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
       "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -6088,6 +6171,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -6134,6 +6218,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -6223,6 +6308,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel": {
@@ -6259,13 +6345,14 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
       "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -6404,6 +6491,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/which": {
@@ -6425,6 +6513,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6459,7 +6548,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -6492,6 +6582,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6513,6 +6604,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6528,6 +6620,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -6545,6 +6638,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -6553,6 +6647,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -6575,6 +6670,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6647,6 +6743,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -6770,7 +6867,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.27.1",
@@ -7647,6 +7745,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
       "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "dev": true,
       "requires": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -7801,12 +7900,13 @@
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
     },
-    "@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true
     },
     "@tybys/wasm-util": {
@@ -7910,7 +8010,7 @@
       "version": "20.4.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.7.tgz",
       "integrity": "sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==",
-      "devOptional": true
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.3",
@@ -7937,6 +8037,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -8266,7 +8367,8 @@
     "agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true
     },
     "ajv": {
       "version": "6.14.0",
@@ -8300,12 +8402,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -8323,12 +8427,14 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
       "requires": {
         "tslib": "^2.0.1"
       }
@@ -8337,6 +8443,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "requires": {}
     },
     "babel-jest": {
@@ -8419,12 +8526,14 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "requires": {}
     },
     "bare-fs": {
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
       "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "dev": true,
       "requires": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -8436,12 +8545,14 @@
     "bare-os": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
-      "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g=="
+      "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
+      "dev": true
     },
     "bare-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "requires": {
         "bare-os": "^3.0.1"
       }
@@ -8450,6 +8561,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
       "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "dev": true,
       "requires": {
         "streamx": "^2.21.0",
         "teex": "^1.0.1"
@@ -8459,6 +8571,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
       "requires": {
         "bare-path": "^3.0.0"
       }
@@ -8466,7 +8579,8 @@
     "basic-ftp": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.12",
@@ -8512,7 +8626,8 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -8523,7 +8638,8 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -8557,6 +8673,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
       "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
       "requires": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -8578,6 +8695,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -8600,6 +8718,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -8607,7 +8726,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8625,6 +8745,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
       "requires": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8646,12 +8767,14 @@
     "data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true
     },
     "debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.3"
       }
@@ -8679,6 +8802,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
       "requires": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -8695,6 +8819,7 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "dev": true,
       "peer": true
     },
     "eastasianwidth": {
@@ -8718,12 +8843,14 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -8731,12 +8858,14 @@
     "env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -8744,7 +8873,8 @@
     "escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -8756,6 +8886,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -8879,7 +9010,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.5.0",
@@ -8902,17 +9034,20 @@
     "estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "requires": {
         "bare-events": "^2.7.0"
       }
@@ -8966,6 +9101,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -8988,7 +9124,8 @@
     "fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -9015,6 +9152,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -9103,7 +9241,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -9115,6 +9254,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -9123,6 +9263,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
       "requires": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -9206,6 +9347,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "requires": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -9215,6 +9357,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "requires": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -9236,6 +9379,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -9276,12 +9420,14 @@
     "ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -9292,7 +9438,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -9823,12 +9970,14 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -9848,7 +9997,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -9902,7 +10052,8 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -9922,7 +10073,8 @@
     "lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true
     },
     "make-dir": {
       "version": "4.0.0",
@@ -9982,12 +10134,14 @@
     "mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "napi-postinstall": {
       "version": "0.3.4",
@@ -10004,7 +10158,8 @@
     "netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -10037,6 +10192,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -10092,6 +10248,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
       "requires": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -10107,6 +10264,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
       "requires": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -10122,6 +10280,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -10130,6 +10289,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10176,12 +10336,14 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -10312,12 +10474,14 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
       "requires": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -10332,12 +10496,14 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -10353,6 +10519,7 @@
       "version": "24.37.5",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.5.tgz",
       "integrity": "sha512-3PAOIQLceyEmn1Fi76GkGO2EVxztv5OtdlB1m8hMUZL3f8KDHnlvXbvCXv+Ls7KzF1R0KdKBqLuT/Hhrok12hQ==",
+      "dev": true,
       "requires": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
@@ -10366,6 +10533,7 @@
       "version": "24.37.5",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
       "integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
+      "dev": true,
       "requires": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
@@ -10391,7 +10559,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
     },
     "resolve-cwd": {
       "version": "3.0.0",
@@ -10413,12 +10582,14 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
     },
     "semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -10450,12 +10621,14 @@
     "smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
     },
     "socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "requires": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -10465,6 +10638,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
       "requires": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -10475,7 +10649,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -10514,6 +10688,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
       "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
       "requires": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -10534,6 +10709,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10555,6 +10731,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -10608,6 +10785,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
       "requires": {
         "bare-fs": "^4.0.1",
         "bare-path": "^3.0.0",
@@ -10619,6 +10797,7 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
       "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
       "requires": {
         "b4a": "^1.6.4",
         "bare-fs": "^4.5.5",
@@ -10630,6 +10809,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
       "requires": {
         "streamx": "^2.12.5"
       }
@@ -10665,6 +10845,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
       "requires": {
         "b4a": "^1.6.4"
       }
@@ -10720,7 +10901,8 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "tunnel": {
       "version": "0.0.6",
@@ -10745,13 +10927,14 @@
     "typed-query-selector": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
-      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA=="
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "dev": true
     },
     "typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "peer": true
     },
     "typescript-eslint": {
@@ -10836,7 +11019,8 @@
     "webdriver-bidi-protocol": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
-      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",
@@ -10851,6 +11035,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10871,7 +11056,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "5.0.1",
@@ -10895,12 +11081,14 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
       "requires": {}
     },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yallist": {
       "version": "3.1.1",
@@ -10912,6 +11100,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10925,12 +11114,14 @@
     "yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -10945,7 +11136,8 @@
     "zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.11.1",
-    "@actions/exec": "^2.0.0",
-    "puppeteer": "^24.37.5",
-    "puppeteer-core": "^24.3.0"
+    "@actions/exec": "^2.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.2.0",
@@ -44,6 +42,8 @@
     "jest": "^30.2.0",
     "playwright": "^1.58.2",
     "prettier": "^3.6.2",
+    "puppeteer": "^24.37.5",
+    "puppeteer-core": "^24.3.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.56.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,13 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/exec": "^2.0.0",
-    "puppeteer": "^24.37.5"
+    "puppeteer": "^24.37.5",
+    "puppeteer-core": "^24.3.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.2.0",
+    "@swc/core": "^1.15.18",
+    "@swc/jest": "^0.2.39",
     "@tsconfig/node20": "^20.1.9",
     "@types/jest": "^30.0.0",
     "@vercel/ncc": "^0.38.4",
@@ -39,8 +42,8 @@
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.3.0",
     "jest": "^30.2.0",
+    "playwright": "^1.58.2",
     "prettier": "^3.6.2",
-    "ts-jest": "^29.4.6",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.56.1"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@jest/globals": "^30.2.0",
     "@swc/core": "^1.15.18",
     "@swc/jest": "^0.2.39",
-    "@tsconfig/node20": "^20.1.9",
+    "@tsconfig/node24": "^24.0.4",
     "@types/jest": "^30.0.0",
     "@vercel/ncc": "^0.38.4",
     "eslint": "^9.39.2",
@@ -44,7 +44,7 @@
     "prettier": "^3.6.2",
     "puppeteer": "^24.37.5",
     "puppeteer-core": "^24.3.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=24.0.0",
     "npm": ">=8.11.0"
   },
   "dependencies": {

--- a/src/browser/engine.ts
+++ b/src/browser/engine.ts
@@ -1,0 +1,15 @@
+export type EngineName = "lightpanda" | "playwright" | "puppeteer";
+
+export type BrowserName = "chromium" | "firefox" | "webkit";
+
+export interface SmokeTestOptions {
+  url: string;
+  selector: string;
+  endpoint?: string;
+  basicAuthUser?: string;
+  basicAuthPassword?: string;
+}
+
+export interface BrowserEngine {
+  runSmokeTest(options: SmokeTestOptions): Promise<void>;
+}

--- a/src/browser/engine.ts
+++ b/src/browser/engine.ts
@@ -1,6 +1,10 @@
-export type EngineName = "lightpanda" | "playwright" | "puppeteer";
+export type EngineName =
+  | "lightpanda"
+  | "puppeteer"
+  | "playwright-chrome"
+  | "playwright-firefox";
 
-export type BrowserName = "chromium" | "firefox" | "webkit";
+export type BrowserName = "chromium" | "firefox";
 
 export interface SmokeTestOptions {
   url: string;

--- a/src/browser/engine.ts
+++ b/src/browser/engine.ts
@@ -6,8 +6,6 @@ export interface SmokeTestOptions {
   url: string;
   selector: string;
   endpoint?: string;
-  basicAuthUser?: string;
-  basicAuthPassword?: string;
 }
 
 export interface BrowserEngine {

--- a/src/browser/factory.test.ts
+++ b/src/browser/factory.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "@jest/globals";
+import { createEngine } from "./factory";
+import { LightpandaEngine } from "./lightpandaEngine";
+import { PuppeteerEngine } from "./puppeteerEngine";
+import { PlaywrightEngine } from "./playwrightEngine";
+
+describe("createEngine()", () => {
+  it("returns LightpandaEngine by default", () => {
+    const engine = createEngine("", "");
+    expect(engine).toBeInstanceOf(LightpandaEngine);
+  });
+
+  it("returns PuppeteerEngine when engine is puppeteer", () => {
+    const engine = createEngine("puppeteer", "");
+    expect(engine).toBeInstanceOf(PuppeteerEngine);
+  });
+
+  it("returns PlaywrightEngine when engine is playwright", () => {
+    const engine = createEngine("playwright", "firefox");
+    expect(engine).toBeInstanceOf(PlaywrightEngine);
+  });
+});

--- a/src/browser/factory.test.ts
+++ b/src/browser/factory.test.ts
@@ -6,17 +6,22 @@ import { PlaywrightEngine } from "./playwrightEngine";
 
 describe("createEngine()", () => {
   it("returns LightpandaEngine by default", () => {
-    const engine = createEngine("", "");
+    const engine = createEngine("");
     expect(engine).toBeInstanceOf(LightpandaEngine);
   });
 
   it("returns PuppeteerEngine when engine is puppeteer", () => {
-    const engine = createEngine("puppeteer", "");
+    const engine = createEngine("puppeteer");
     expect(engine).toBeInstanceOf(PuppeteerEngine);
   });
 
-  it("returns PlaywrightEngine when engine is playwright", () => {
-    const engine = createEngine("playwright", "firefox");
+  it("returns PlaywrightEngine (chromium) when engine is playwright-chrome", () => {
+    const engine = createEngine("playwright-chrome");
+    expect(engine).toBeInstanceOf(PlaywrightEngine);
+  });
+
+  it("returns PlaywrightEngine (firefox) when engine is playwright-firefox", () => {
+    const engine = createEngine("playwright-firefox");
     expect(engine).toBeInstanceOf(PlaywrightEngine);
   });
 });

--- a/src/browser/factory.ts
+++ b/src/browser/factory.ts
@@ -1,22 +1,21 @@
-import type { BrowserName, BrowserEngine, EngineName } from "./engine";
+import type { BrowserEngine, EngineName } from "./engine";
 import { PuppeteerEngine } from "./puppeteerEngine";
 import { LightpandaEngine } from "./lightpandaEngine";
 import { PlaywrightEngine } from "./playwrightEngine";
 
-export function createEngine(
-  engineName: string,
-  browserName: string,
-): BrowserEngine {
+export function createEngine(engineName: string): BrowserEngine {
   const normalizedEngine = (engineName || "lightpanda") as EngineName;
-  const normalizedBrowser = (browserName || "chromium") as BrowserName;
 
   switch (normalizedEngine) {
     case "lightpanda":
       return new LightpandaEngine();
-    case "playwright":
-      return new PlaywrightEngine(normalizedBrowser);
     case "puppeteer":
-    default:
       return new PuppeteerEngine();
+    case "playwright-chrome":
+      return new PlaywrightEngine("chromium");
+    case "playwright-firefox":
+      return new PlaywrightEngine("firefox");
+    default:
+      return new LightpandaEngine();
   }
 }

--- a/src/browser/factory.ts
+++ b/src/browser/factory.ts
@@ -1,0 +1,22 @@
+import type { BrowserName, BrowserEngine, EngineName } from "./engine";
+import { PuppeteerEngine } from "./puppeteerEngine";
+import { LightpandaEngine } from "./lightpandaEngine";
+import { PlaywrightEngine } from "./playwrightEngine";
+
+export function createEngine(
+  engineName: string,
+  browserName: string,
+): BrowserEngine {
+  const normalizedEngine = (engineName || "lightpanda") as EngineName;
+  const normalizedBrowser = (browserName || "chromium") as BrowserName;
+
+  switch (normalizedEngine) {
+    case "lightpanda":
+      return new LightpandaEngine();
+    case "playwright":
+      return new PlaywrightEngine(normalizedBrowser);
+    case "puppeteer":
+    default:
+      return new PuppeteerEngine();
+  }
+}

--- a/src/browser/lightpandaEngine.test.ts
+++ b/src/browser/lightpandaEngine.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import type { Browser } from "puppeteer-core";
+import { LightpandaEngine } from "./lightpandaEngine";
+
+const mockConnect = jest.fn();
+
+jest.mock("puppeteer-core", () => ({
+  __esModule: true,
+  default: { connect: () => mockConnect() },
+}));
+
+describe("LightpandaEngine", () => {
+  const engine = new LightpandaEngine();
+
+  let goto: jest.Mock;
+  let waitForSelector: jest.Mock;
+  let waitForRequest: jest.Mock;
+
+  beforeEach(() => {
+    goto = jest.fn();
+    waitForSelector = jest.fn();
+    waitForRequest = jest.fn();
+
+    const fakePage = {
+      goto,
+      waitForSelector,
+      waitForRequest,
+      close: jest.fn(),
+    };
+    const fakeContext = {
+      newPage: jest.fn().mockResolvedValue(fakePage),
+      close: jest.fn(),
+    };
+    const fakeBrowser = {
+      createBrowserContext: jest.fn().mockResolvedValue(fakeContext),
+      disconnect: jest.fn(),
+    } as unknown as Browser;
+
+    mockConnect.mockResolvedValue(fakeBrowser);
+  });
+
+  it("navigates to a specific url", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(goto).toHaveBeenCalledWith("https://inter.net");
+  });
+
+  it("waits for a selector to be in the document", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForSelector).toHaveBeenCalledWith("div");
+  });
+
+  it("waits for a specific request with provided endpoint", async () => {
+    await engine.runSmokeTest({
+      url: "https://inter.net",
+      selector: "div",
+      endpoint: "https://api.inter.net/whoiam",
+    });
+
+    expect(waitForRequest).toHaveBeenCalledWith("https://api.inter.net/whoiam");
+  });
+
+  it("does not wait for a specific request unless endpoint is provided", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForRequest).not.toHaveBeenCalled();
+  });
+
+  it("throws if a specific request with provided endpoint is not fetched", async () => {
+    waitForRequest.mockRejectedValueOnce(new Error("Request not performed"));
+
+    await expect(
+      engine.runSmokeTest({
+        url: "https://inter.net",
+        selector: "div",
+        endpoint: "https://api.inter.net/whoiam",
+      }),
+    ).rejects.toThrow("Request not performed");
+  });
+});

--- a/src/browser/lightpandaEngine.ts
+++ b/src/browser/lightpandaEngine.ts
@@ -14,13 +14,6 @@ export class LightpandaEngine implements BrowserEngine {
       const context = await browser.createBrowserContext();
       const page = await context.newPage();
 
-      if (options.basicAuthUser || options.basicAuthPassword) {
-        await page.authenticate({
-          username: options.basicAuthUser ?? "",
-          password: options.basicAuthPassword ?? "",
-        });
-      }
-
       const requestCheck = options.endpoint
         ? page.waitForRequest(options.endpoint)
         : Promise.resolve();

--- a/src/browser/lightpandaEngine.ts
+++ b/src/browser/lightpandaEngine.ts
@@ -1,0 +1,38 @@
+import puppeteer from "puppeteer-core";
+import type { BrowserEngine, SmokeTestOptions } from "./engine";
+
+const DEFAULT_LIGHTPANDA_ENDPOINT =
+  process.env.LIGHTPANDA_BROWSER_ENDPOINT ?? "ws://127.0.0.1:9222";
+
+export class LightpandaEngine implements BrowserEngine {
+  async runSmokeTest(options: SmokeTestOptions): Promise<void> {
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: DEFAULT_LIGHTPANDA_ENDPOINT,
+    });
+
+    try {
+      const context = await browser.createBrowserContext();
+      const page = await context.newPage();
+
+      if (options.basicAuthUser || options.basicAuthPassword) {
+        await page.authenticate({
+          username: options.basicAuthUser ?? "",
+          password: options.basicAuthPassword ?? "",
+        });
+      }
+
+      const requestCheck = options.endpoint
+        ? page.waitForRequest(options.endpoint)
+        : Promise.resolve();
+
+      await page.goto(options.url);
+
+      await Promise.all([requestCheck, page.waitForSelector(options.selector)]);
+
+      await page.close();
+      await context.close();
+    } finally {
+      await browser.disconnect();
+    }
+  }
+}

--- a/src/browser/playwrightEngine.test.ts
+++ b/src/browser/playwrightEngine.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import type { Browser } from "playwright";
+import { PlaywrightEngine } from "./playwrightEngine";
+
+const mockChromiumLaunch = jest.fn();
+const mockFirefoxLaunch = jest.fn();
+
+jest.mock("playwright", () => ({
+  chromium: { launch: () => mockChromiumLaunch() },
+  firefox: { launch: () => mockFirefoxLaunch() },
+}));
+
+describe("PlaywrightEngine", () => {
+  let goto: jest.Mock;
+  let waitForSelector: jest.Mock;
+  let waitForRequest: jest.Mock;
+
+  beforeEach(() => {
+    goto = jest.fn();
+    waitForSelector = jest.fn();
+    waitForRequest = jest.fn();
+
+    const fakePage = {
+      goto,
+      waitForSelector,
+      waitForRequest,
+      close: jest.fn(),
+    };
+    const fakeContext = {
+      newPage: jest.fn().mockResolvedValue(fakePage),
+      close: jest.fn(),
+    };
+    const fakeBrowser = {
+      newContext: jest.fn().mockResolvedValue(fakeContext),
+      close: jest.fn(),
+    } as unknown as Browser;
+
+    mockChromiumLaunch.mockResolvedValue(fakeBrowser);
+    mockFirefoxLaunch.mockResolvedValue(fakeBrowser);
+  });
+
+  it("navigates to a specific url", async () => {
+    const engine = new PlaywrightEngine("chromium");
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(goto).toHaveBeenCalledWith("https://inter.net");
+  });
+
+  it("waits for a selector to be in the document", async () => {
+    const engine = new PlaywrightEngine("chromium");
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForSelector).toHaveBeenCalledWith("div");
+  });
+
+  it("waits for a specific request with provided endpoint", async () => {
+    const engine = new PlaywrightEngine("chromium");
+    await engine.runSmokeTest({
+      url: "https://inter.net",
+      selector: "div",
+      endpoint: "https://api.inter.net/whoiam",
+    });
+
+    expect(waitForRequest).toHaveBeenCalledWith("https://api.inter.net/whoiam");
+  });
+
+  it("does not wait for a specific request unless endpoint is provided", async () => {
+    const engine = new PlaywrightEngine("chromium");
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForRequest).not.toHaveBeenCalled();
+  });
+
+  it("throws if a specific request with provided endpoint is not fetched", async () => {
+    const engine = new PlaywrightEngine("chromium");
+    waitForRequest.mockRejectedValueOnce(new Error("Request not performed"));
+
+    await expect(
+      engine.runSmokeTest({
+        url: "https://inter.net",
+        selector: "div",
+        endpoint: "https://api.inter.net/whoiam",
+      }),
+    ).rejects.toThrow("Request not performed");
+  });
+
+  it("uses the firefox browser when browserName is firefox", async () => {
+    const engine = new PlaywrightEngine("firefox");
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(mockFirefoxLaunch).toHaveBeenCalledTimes(1);
+    expect(mockChromiumLaunch).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/playwrightEngine.ts
+++ b/src/browser/playwrightEngine.ts
@@ -1,4 +1,4 @@
-import { chromium, firefox, webkit, type Browser } from "playwright";
+import { chromium, firefox, type Browser } from "playwright";
 import type { BrowserEngine, BrowserName, SmokeTestOptions } from "./engine";
 
 function getPlaywrightBrowser(browserName: BrowserName) {

--- a/src/browser/playwrightEngine.ts
+++ b/src/browser/playwrightEngine.ts
@@ -1,0 +1,54 @@
+import { chromium, firefox, webkit, type Browser } from "playwright";
+import type { BrowserEngine, BrowserName, SmokeTestOptions } from "./engine";
+
+function getPlaywrightBrowser(browserName: BrowserName) {
+  switch (browserName) {
+    case "firefox":
+      return firefox;
+    case "webkit":
+      return webkit;
+    case "chromium":
+    default:
+      return chromium;
+  }
+}
+
+export class PlaywrightEngine implements BrowserEngine {
+  constructor(private readonly browserName: BrowserName = "chromium") {}
+
+  async runSmokeTest(options: SmokeTestOptions): Promise<void> {
+    const browserType = getPlaywrightBrowser(this.browserName);
+    const browser: Browser = await browserType.launch();
+
+    try {
+      const context = await browser.newContext({
+        httpCredentials:
+          options.basicAuthUser || options.basicAuthPassword
+            ? {
+                username: options.basicAuthUser ?? "",
+                password: options.basicAuthPassword ?? "",
+              }
+            : undefined,
+      });
+
+      const page = await context.newPage();
+
+      if (options.endpoint) {
+        const requestPromise = page.waitForRequest(options.endpoint);
+        await page.goto(options.url);
+        await Promise.all([
+          requestPromise,
+          page.waitForSelector(options.selector),
+        ]);
+      } else {
+        await page.goto(options.url);
+        await page.waitForSelector(options.selector);
+      }
+
+      await page.close();
+      await context.close();
+    } finally {
+      await browser.close();
+    }
+  }
+}

--- a/src/browser/playwrightEngine.ts
+++ b/src/browser/playwrightEngine.ts
@@ -5,8 +5,6 @@ function getPlaywrightBrowser(browserName: BrowserName) {
   switch (browserName) {
     case "firefox":
       return firefox;
-    case "webkit":
-      return webkit;
     case "chromium":
     default:
       return chromium;

--- a/src/browser/playwrightEngine.ts
+++ b/src/browser/playwrightEngine.ts
@@ -21,15 +21,7 @@ export class PlaywrightEngine implements BrowserEngine {
     const browser: Browser = await browserType.launch();
 
     try {
-      const context = await browser.newContext({
-        httpCredentials:
-          options.basicAuthUser || options.basicAuthPassword
-            ? {
-                username: options.basicAuthUser ?? "",
-                password: options.basicAuthPassword ?? "",
-              }
-            : undefined,
-      });
+      const context = await browser.newContext();
 
       const page = await context.newPage();
 

--- a/src/browser/puppeteerEngine.test.ts
+++ b/src/browser/puppeteerEngine.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import type { Browser } from "puppeteer";
+import { PuppeteerEngine } from "./puppeteerEngine";
+
+const mockLaunch = jest.fn();
+
+jest.mock("puppeteer", () => ({
+  __esModule: true,
+  default: { launch: () => mockLaunch() },
+}));
+
+jest.mock("../utils/findChromePath", () => ({
+  findChromePath: jest.fn().mockResolvedValue("/path/to/chrome"),
+}));
+
+describe("PuppeteerEngine", () => {
+  const engine = new PuppeteerEngine();
+
+  let goto: jest.Mock;
+  let waitForSelector: jest.Mock;
+  let waitForRequest: jest.Mock;
+
+  beforeEach(() => {
+    goto = jest.fn();
+    waitForSelector = jest.fn();
+    waitForRequest = jest.fn();
+
+    const fakePage = { goto, waitForSelector, waitForRequest };
+    const fakeBrowser = {
+      newPage: jest.fn().mockResolvedValue(fakePage),
+      close: jest.fn(),
+    } as unknown as Browser;
+
+    mockLaunch.mockResolvedValue(fakeBrowser);
+  });
+
+  it("navigates to a specific url", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(goto).toHaveBeenCalledWith("https://inter.net");
+  });
+
+  it("waits for a selector to be in the document", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForSelector).toHaveBeenCalledWith("div");
+  });
+
+  it("waits for a specific request with provided endpoint", async () => {
+    await engine.runSmokeTest({
+      url: "https://inter.net",
+      selector: "div",
+      endpoint: "https://api.inter.net/whoiam",
+    });
+
+    expect(waitForRequest).toHaveBeenCalledWith("https://api.inter.net/whoiam");
+  });
+
+  it("does not wait for a specific request unless endpoint is provided", async () => {
+    await engine.runSmokeTest({ url: "https://inter.net", selector: "div" });
+
+    expect(waitForRequest).not.toHaveBeenCalled();
+  });
+
+  it("throws if a specific request with provided endpoint is not fetched", async () => {
+    waitForRequest.mockRejectedValueOnce(new Error("Request not performed"));
+
+    await expect(
+      engine.runSmokeTest({
+        url: "https://inter.net",
+        selector: "div",
+        endpoint: "https://api.inter.net/whoiam",
+      }),
+    ).rejects.toThrow("Request not performed");
+  });
+});

--- a/src/browser/puppeteerEngine.ts
+++ b/src/browser/puppeteerEngine.ts
@@ -1,0 +1,35 @@
+import puppeteer from "puppeteer";
+import type { BrowserEngine, SmokeTestOptions } from "./engine";
+import { findChromePath } from "../utils/findChromePath";
+
+export class PuppeteerEngine implements BrowserEngine {
+  async runSmokeTest(options: SmokeTestOptions): Promise<void> {
+    const chromePath = await findChromePath();
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      executablePath: chromePath,
+    });
+
+    try {
+      const page = await browser.newPage();
+
+      if (options.basicAuthUser || options.basicAuthPassword) {
+        await page.authenticate({
+          username: options.basicAuthUser ?? "",
+          password: options.basicAuthPassword ?? "",
+        });
+      }
+
+      const requestCheck = options.endpoint
+        ? page.waitForRequest(options.endpoint)
+        : Promise.resolve();
+
+      await page.goto(options.url);
+
+      await Promise.all([requestCheck, page.waitForSelector(options.selector)]);
+    } finally {
+      await browser.close();
+    }
+  }
+}

--- a/src/browser/puppeteerEngine.ts
+++ b/src/browser/puppeteerEngine.ts
@@ -14,13 +14,6 @@ export class PuppeteerEngine implements BrowserEngine {
     try {
       const page = await browser.newPage();
 
-      if (options.basicAuthUser || options.basicAuthPassword) {
-        await page.authenticate({
-          username: options.basicAuthUser ?? "",
-          password: options.basicAuthPassword ?? "",
-        });
-      }
-
       const requestCheck = options.endpoint
         ? page.waitForRequest(options.endpoint)
         : Promise.resolve();

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -6,8 +6,6 @@ const mockGetArgs = jest.fn().mockReturnValue({
   url: "https://inter.net",
   selector: "div",
   endpoint: undefined,
-  basicAuthUser: undefined,
-  basicAuthPassword: undefined,
   engine: "puppeteer",
   browser: "chromium",
 });
@@ -39,8 +37,6 @@ describe("run()", () => {
       url: "https://inter.net",
       selector: "div",
       endpoint: undefined,
-      basicAuthUser: undefined,
-      basicAuthPassword: undefined,
     });
   });
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,128 +1,51 @@
 import { describe, it, expect } from "@jest/globals";
 import { run } from "./run";
 
-const mockGetArgs = jest.fn().mockReturnValue({});
-const mockFindChromePath = jest.fn();
-
-const mockAuthenticate = jest.fn();
-const mockWaitForRequest = jest.fn();
-const mockWaitForSelector = jest.fn();
-const mockGoto = jest.fn();
-const mockClose = jest.fn();
-
-const mockNewPage = jest.fn().mockResolvedValue({
-  authenticate: (options: unknown) => mockAuthenticate(options),
-  waitForRequest: (url: string) => mockWaitForRequest(url),
-  waitForSelector: (selector: string) => mockWaitForSelector(selector),
-  goto: (url: string) => mockGoto(url),
+const mockGetArgs = jest.fn().mockReturnValue({
+  waitMs: 0,
+  url: "https://inter.net",
+  selector: "div",
+  endpoint: undefined,
+  basicAuthUser: undefined,
+  basicAuthPassword: undefined,
+  engine: "puppeteer",
+  browser: "chromium",
 });
 
-const mockPuppeteerLaunch = jest.fn().mockResolvedValue({
-  newPage: () => mockNewPage(),
-  close: () => mockClose(),
-});
+const mockRunSmokeTest = jest.fn();
 
 const mockSetFailed = jest.fn();
 
-jest.mock("puppeteer", () => ({
-  __esModule: true,
-  default: {
-    launch: (options: unknown) => mockPuppeteerLaunch(options),
-  },
-}));
-
 jest.mock("@actions/core", () => ({
   setFailed: (message: string) => mockSetFailed(message),
+  info: jest.fn(),
 }));
 
 jest.mock("./utils/getArgs", () => ({
   getArgs: () => mockGetArgs(),
 }));
 
-jest.mock("./utils/findChromePath", () => ({
-  findChromePath: () => mockFindChromePath(),
+jest.mock("./browser/factory", () => ({
+  createEngine: () => ({
+    runSmokeTest: (options: unknown) => mockRunSmokeTest(options),
+  }),
 }));
 
 describe("run()", () => {
-  it("launches a Puppeteer instance and opens a new page", async () => {
-    const chromePath = "/path/to/chrome";
-    mockFindChromePath.mockResolvedValueOnce(chromePath);
-
+  it("passes the correct options to the engine", async () => {
     await run();
 
-    expect(mockPuppeteerLaunch).toHaveBeenCalledWith({
-      headless: true,
-      executablePath: chromePath,
-    });
-  });
-
-  it("does not authenticate unless credentials are provided", async () => {
-    await run();
-    expect(mockAuthenticate).not.toHaveBeenCalled();
-  });
-
-  it("authenticates with provided credentials", async () => {
-    mockGetArgs.mockReturnValueOnce({
-      basicAuthUser: "user",
-      basicAuthPassword: "password",
-    });
-
-    await run();
-
-    expect(mockAuthenticate).toHaveBeenCalledWith({
-      username: "user",
-      password: "password",
-    });
-  });
-
-  it("does not wait for a specific request unless endpoint is provided", async () => {
-    await run();
-    expect(mockWaitForRequest).not.toHaveBeenCalled();
-  });
-
-  it("waits for a specific request with provided endpoint", async () => {
-    mockGetArgs.mockReturnValueOnce({
-      endpoint: "https://api.inter.net",
-    });
-
-    await run();
-
-    expect(mockWaitForRequest).toHaveBeenCalledWith("https://api.inter.net");
-  });
-
-  it("navigates to a specific url", async () => {
-    mockGetArgs.mockReturnValueOnce({
+    expect(mockRunSmokeTest).toHaveBeenCalledWith({
       url: "https://inter.net",
-    });
-
-    await run();
-
-    expect(mockGoto).toHaveBeenCalledWith("https://inter.net");
-  });
-
-  it("throws if a specific request with provided endpoint is not fetched", async () => {
-    mockGetArgs.mockReturnValueOnce({
-      endpoint: "https://api.inter.net",
-    });
-    mockWaitForRequest.mockRejectedValueOnce(undefined);
-
-    await run();
-
-    expect(mockSetFailed).toHaveBeenCalledWith("Smoke test failed");
-  });
-
-  it("waits for a selector to be in the document", async () => {
-    mockGetArgs.mockReturnValueOnce({
       selector: "div",
+      endpoint: undefined,
+      basicAuthUser: undefined,
+      basicAuthPassword: undefined,
     });
-
-    await run();
-
-    expect(mockWaitForSelector).toHaveBeenCalledWith("div");
   });
 
-  it("throws if a selector is not found", async () => {
-    mockWaitForSelector.mockRejectedValueOnce(undefined);
+  it("marks the run as failed when the engine throws", async () => {
+    mockRunSmokeTest.mockRejectedValueOnce(new Error("boom"));
 
     await run();
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -7,7 +7,6 @@ const mockGetArgs = jest.fn().mockReturnValue({
   selector: "div",
   endpoint: undefined,
   engine: "puppeteer",
-  browser: "chromium",
 });
 
 const mockRunSmokeTest = jest.fn();

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,13 +4,7 @@ import { getArgs } from "./utils/getArgs";
 import { createEngine } from "./browser/factory";
 
 export async function run(): Promise<void> {
-  const {
-    waitMs,
-    url,
-    selector,
-    endpoint,
-    engine,
-  } = getArgs();
+  const { waitMs, url, selector, endpoint, engine } = getArgs();
 
   await wait(waitMs);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,12 +9,9 @@ export async function run(): Promise<void> {
     url,
     selector,
     endpoint,
-    basicAuthUser,
-    basicAuthPassword,
     engine,
     browser,
   } = getArgs();
-  const useBasicAuth = Boolean(basicAuthUser || basicAuthPassword);
 
   await wait(waitMs);
 
@@ -25,8 +22,6 @@ export async function run(): Promise<void> {
       url,
       selector,
       endpoint,
-      basicAuthUser: useBasicAuth ? basicAuthUser : undefined,
-      basicAuthPassword: useBasicAuth ? basicAuthPassword : undefined,
     });
 
     info("Smoke test succeeded");

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,45 +1,36 @@
 import { setFailed, info } from "@actions/core";
-import puppeteer from "puppeteer";
 import { wait } from "./utils/wait";
 import { getArgs } from "./utils/getArgs";
-import { findChromePath } from "./utils/findChromePath";
+import { createEngine } from "./browser/factory";
 
 export async function run(): Promise<void> {
-  const { waitMs, url, selector, endpoint, basicAuthUser, basicAuthPassword } =
-    getArgs();
+  const {
+    waitMs,
+    url,
+    selector,
+    endpoint,
+    basicAuthUser,
+    basicAuthPassword,
+    engine,
+    browser,
+  } = getArgs();
   const useBasicAuth = Boolean(basicAuthUser || basicAuthPassword);
 
   await wait(waitMs);
 
-  const chromePath = await findChromePath();
-
-  const browser = await puppeteer.launch({
-    headless: true,
-    executablePath: chromePath,
-  });
+  const engineInstance = createEngine(engine, browser);
 
   try {
-    const page = await browser.newPage();
-
-    if (useBasicAuth) {
-      await page.authenticate({
-        username: basicAuthUser,
-        password: basicAuthPassword,
-      });
-    }
-
-    const requestCheck = endpoint
-      ? page.waitForRequest(endpoint)
-      : Promise.resolve();
-
-    await page.goto(url);
-
-    await Promise.all([requestCheck, page.waitForSelector(selector)]);
+    await engineInstance.runSmokeTest({
+      url,
+      selector,
+      endpoint,
+      basicAuthUser: useBasicAuth ? basicAuthUser : undefined,
+      basicAuthPassword: useBasicAuth ? basicAuthPassword : undefined,
+    });
 
     info("Smoke test succeeded");
   } catch {
     setFailed("Smoke test failed");
   }
-
-  await browser.close();
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,12 +10,11 @@ export async function run(): Promise<void> {
     selector,
     endpoint,
     engine,
-    browser,
   } = getArgs();
 
   await wait(waitMs);
 
-  const engineInstance = createEngine(engine, browser);
+  const engineInstance = createEngine(engine);
 
   try {
     await engineInstance.runSmokeTest({

--- a/src/utils/getArgs.test.ts
+++ b/src/utils/getArgs.test.ts
@@ -16,7 +16,16 @@ function clearInputs(keys: string[]) {
 
 describe("getArgs()", () => {
   afterEach(() => {
-    clearInputs(["target-url", "target-selector"]);
+    clearInputs([
+      "target-url",
+      "target-selector",
+      "wait-on-start",
+      "request-url",
+      "http-auth-username",
+      "http-auth-password",
+      "engine",
+      "browser",
+    ]);
   });
 
   it("throws when target-url is missing", () => {
@@ -104,5 +113,27 @@ describe("getArgs()", () => {
     });
 
     expect(getArgs().basicAuthPassword).toBe("password");
+  });
+
+  it("returns default engine and browser values", () => {
+    useInputs({
+      "target-url": "https://inter.net",
+      "target-selector": "div",
+    });
+
+    expect(getArgs().engine).toBe("lightpanda");
+    expect(getArgs().browser).toBe("chromium");
+  });
+
+  it("returns custom engine and browser values", () => {
+    useInputs({
+      "target-url": "https://inter.net",
+      "target-selector": "div",
+      engine: "playwright",
+      browser: "firefox",
+    });
+
+    expect(getArgs().engine).toBe("playwright");
+    expect(getArgs().browser).toBe("firefox");
   });
 });

--- a/src/utils/getArgs.test.ts
+++ b/src/utils/getArgs.test.ts
@@ -22,7 +22,6 @@ describe("getArgs()", () => {
       "wait-on-start",
       "request-url",
       "engine",
-      "browser",
     ]);
   });
 
@@ -93,25 +92,22 @@ describe("getArgs()", () => {
     expect(getArgs().endpoint).toBe("https://api.inter.net/whoiam");
   });
 
-  it("returns default engine and browser values", () => {
+  it("returns a default engine value", () => {
     useInputs({
       "target-url": "https://inter.net",
       "target-selector": "div",
     });
 
     expect(getArgs().engine).toBe("lightpanda");
-    expect(getArgs().browser).toBe("chromium");
   });
 
-  it("returns custom engine and browser values", () => {
+  it("returns a custom engine value", () => {
     useInputs({
       "target-url": "https://inter.net",
       "target-selector": "div",
-      engine: "playwright",
-      browser: "firefox",
+      engine: "playwright-firefox",
     });
 
-    expect(getArgs().engine).toBe("playwright");
-    expect(getArgs().browser).toBe("firefox");
+    expect(getArgs().engine).toBe("playwright-firefox");
   });
 });

--- a/src/utils/getArgs.test.ts
+++ b/src/utils/getArgs.test.ts
@@ -21,8 +21,6 @@ describe("getArgs()", () => {
       "target-selector",
       "wait-on-start",
       "request-url",
-      "http-auth-username",
-      "http-auth-password",
       "engine",
       "browser",
     ]);
@@ -93,26 +91,6 @@ describe("getArgs()", () => {
     });
 
     expect(getArgs().endpoint).toBe("https://api.inter.net/whoiam");
-  });
-
-  it("returns some username", () => {
-    useInputs({
-      "target-url": "https://inter.net",
-      "target-selector": "div",
-      "http-auth-username": "user",
-    });
-
-    expect(getArgs().basicAuthUser).toBe("user");
-  });
-
-  it("returns some password", () => {
-    useInputs({
-      "target-url": "https://inter.net",
-      "target-selector": "div",
-      "http-auth-password": "password",
-    });
-
-    expect(getArgs().basicAuthPassword).toBe("password");
   });
 
   it("returns default engine and browser values", () => {

--- a/src/utils/getArgs.ts
+++ b/src/utils/getArgs.ts
@@ -9,6 +9,5 @@ export function getArgs() {
     selector: getInput("target-selector", { required: true }),
     endpoint: getInput("request-url"),
     engine: getInput("engine") || "lightpanda",
-    browser: getInput("browser") || "chromium",
   };
 }

--- a/src/utils/getArgs.ts
+++ b/src/utils/getArgs.ts
@@ -5,13 +5,12 @@ export function getArgs() {
 
   return {
     waitMs: waitMsInput ? parseInt(waitMsInput) : 0,
-
     url: getInput("target-url", { required: true }),
     selector: getInput("target-selector", { required: true }),
-
     endpoint: getInput("request-url"),
-
     basicAuthUser: getInput("http-auth-username"),
     basicAuthPassword: getInput("http-auth-password"),
+    engine: getInput("engine") || "lightpanda",
+    browser: getInput("browser") || "chromium",
   };
 }

--- a/src/utils/getArgs.ts
+++ b/src/utils/getArgs.ts
@@ -8,8 +8,6 @@ export function getArgs() {
     url: getInput("target-url", { required: true }),
     selector: getInput("target-selector", { required: true }),
     endpoint: getInput("request-url"),
-    basicAuthUser: getInput("http-auth-username"),
-    basicAuthPassword: getInput("http-auth-password"),
     engine: getInput("engine") || "lightpanda",
     browser: getInput("browser") || "chromium",
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
## Summary

- Switch the SPA smoke-test GitHub Action to a pluggable engine architecture with Lightpanda as the default.
- Add Playwright (Chrome/Firefox) and Puppeteer support behind a single unified `engine` option.
- Bump the action runtime to Node 24 LTS, remove HTTP basic auth support, and modernize Jest to use @swc/jest.

## Details

- **Engines**: Introduce a `BrowserEngine` abstraction with `LightpandaEngine`, `PuppeteerEngine`, and `PlaywrightEngine`, selected via a unified `engine` input (`lightpanda`, `puppeteer`, `playwright-chrome`, `playwright-firefox`).
- **Action & workflow**: Update `action.yml` and add a `Manual SPA smoke test` `workflow_dispatch` entrypoint to trigger ad-hoc runs.
- **Tooling**: Bump to Node 24 LTS and switch Jest from ts-jest to @swc/jest; add links in the README to Lightpanda, Puppeteer, and Playwright.

## Test plan

- [x] `npm run build`
- [x] `npm test` (Jest suite, including engine factory and argument parsing tests)
